### PR TITLE
Improve handling of invalid art URLs

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "1.5", features = [] }
 log = "0.4.20"
 futures = { version = "0.3.28", features = [] }
 futures-util = "0.3.28"
-tauri = { version = "1.5", features = ["shell-open", "system-tray", "macos-private-api"] }
+tauri = { version = "1.5", features = ["shell-open", "system-tray", "http-all", "macos-private-api"] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", features = ["colored"] }
 tauri-plugin-positioner = { version = "1.0.4", features = ["system-tray"] }
 tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,11 @@
             "shell": {
                 "all": false,
                 "open": true
+            },
+            "http": {
+                "all": true,
+                "request": true,
+                "scope": ["http://*", "https://*"]
             }
         },
         "bundle": {

--- a/src/lib/components/TrackInfo.svelte
+++ b/src/lib/components/TrackInfo.svelte
@@ -1,17 +1,22 @@
 <script lang="ts">
     import { isConnected, vibinState } from "../state.ts";
+    import { isUrlOk } from "../utils.ts";
+
+    let isArtImageOk: boolean = true;
 
     $: artUrl = $vibinState.display.art_url;
-    $: haveDisplayDetails = $vibinState.display.line1 || $vibinState.display.line2 || $vibinState.display.line3;
+    $: haveTextDetails = $vibinState.display.line1 || $vibinState.display.line2 || $vibinState.display.line3;
+
+    $: artUrl && isUrlOk(artUrl).then((isOk) => isArtImageOk = isOk);
 </script>
 
 <div class="TrackInfo">
     <div
-        class={"art" + `${!artUrl ? " art-unavailable" : ""}`}
-        style={`background-image: ${artUrl ? `url(${artUrl})` : undefined}`}
+        class={"art" + `${!(artUrl && isArtImageOk) ? " art-unavailable" : ""}`}
+        style={`background-image: ${artUrl && isArtImageOk ? `url(${artUrl})` : undefined}`}
     />
     <div class="details">
-        {#if haveDisplayDetails}
+        {#if haveTextDetails}
             <span class="details-line1">{$vibinState.display.line1 || ""}</span>
             <span class="details-line2">{$vibinState.display.line2 || ""}</span>
             <span class="details-line3">{$vibinState.display.line3 || ""}</span>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/tauri";
+import { fetch, ResponseType } from "@tauri-apps/api/http";
 import * as logger from "tauri-plugin-log-api";
 
 import { DEFAULT_VIBIN_PORT } from "./consts.ts";
@@ -33,8 +34,31 @@ const colorFromCssVar = (cssVarName: string): string | undefined => {
     return undefined;
 }
 
+/**
+ * Check whether the provided url is valid (200-level HTTP response).
+ */
+const isUrlOk = async (url: string, responseType: ResponseType = ResponseType.Binary) => {
+    let isOk = false;
+
+    try {
+        const result = await fetch(url, {
+            method: "GET",
+            responseType,
+            timeout: 5,
+        });
+
+        isOk = result.ok;
+    } catch (e) {
+        logger.warn(`UI could not determine URL validity for ${url}: ${e}`);
+    }
+
+    return isOk;
+}
+
 export {
     colorFromCssVar,
     connectToVibin,
+    isUrlOk,
     logger,
 };
+


### PR DESCRIPTION
Sometimes the streamer returns an art URL which looks valid (it's a string starting with "http://"), but will return a non-200 response. That used to result in rendering an empty art container. It now renders the same "no art" container as when the url is completely missing.

This resulted in the UI performing its own JavaScript HTTP request, which means using Tauri's own fetch API to avoid security/CORS issues.