### PR TITLE
Expose Vibin's streamer power state

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -159,6 +159,7 @@ pub struct ActiveTrack {
 #[derive(Clone, Serialize)]
 pub struct VibinState {
     pub power: Option<String>,
+    pub streamer_power: Option<String>,
     pub amplifier: Option<Amplifier>,
     pub display: StreamerDisplay,
     pub transport: Option<TransportState>,
@@ -170,6 +171,7 @@ impl VibinState {
     pub fn new() -> VibinState {
         VibinState {
             power: Some("off".into()),
+            streamer_power: Some("off".into()),
             amplifier: None,
             display: StreamerDisplay {
                 line1: None,

--- a/src-tauri/src/websocket.rs
+++ b/src-tauri/src/websocket.rs
@@ -61,6 +61,7 @@ struct VibinMessage {
 
 #[derive(Deserialize)]
 struct StreamerPayload {
+    power: Option<String>,
     sources: Option<StreamerSources>,
     display: Option<StreamerDisplay>,
 }
@@ -342,6 +343,7 @@ impl WebSocketConnection {
                     serde_json::from_value(vibin_msg.payload).unwrap();
 
                 vibin_state.power = system_payload.power;
+                vibin_state.streamer_power = system_payload.streamer.power;
 
                 if let Some(amplifier) = system_payload.amplifier {
                     vibin_state.amplifier = Some(Amplifier {

--- a/src/lib/components/VolumeControls.svelte
+++ b/src/lib/components/VolumeControls.svelte
@@ -8,7 +8,7 @@
         IconVolumeOff
     } from "@tabler/icons-svelte";
 
-    import { isPowerOn, vibinState } from "../state.ts";
+    import { isSystemPowerOn, vibinState } from "../state.ts";
     import { toggleMute, volumeDown, volumeSet, volumeUp } from "../vibin_api.ts";
     import { colorFromCssVar } from "../utils.ts";
     import Arc from "./Arc.svelte";
@@ -25,7 +25,7 @@
     $: volumeBigDown = Math.max(volume - bigVolumeChangeAmount, 0.0);
 </script>
 
-{#if $vibinState.amplifier && $isPowerOn}
+{#if $vibinState.amplifier && $isSystemPowerOn}
     <div class="VolumeControls">
         <ToggleButton
             icon={$vibinState.amplifier.mute === "off" ? IconVolume : IconVolumeOff}

--- a/src/lib/components/buttons/PowerButton.svelte
+++ b/src/lib/components/buttons/PowerButton.svelte
@@ -2,7 +2,7 @@
     import { IconPower } from "@tabler/icons-svelte";
     import tinycolor from "tinycolor2";
 
-    import { isConnected, isPowerOn } from "../../state.ts";
+    import { isConnected, isSystemPowerOn } from "../../state.ts";
     import { powerOff, powerOn } from "../../vibin_api.ts";
     import { colorFromCssVar } from "../../utils.ts";
     import IconButton from "./IconButton.svelte";
@@ -10,14 +10,14 @@
     let accentColorBright = colorFromCssVar("--accent-color-bright");
     let accentColorBrighter = tinycolor(accentColorBright).brighten(20).toString();
 
-    $: color = isPowerOn ? accentColorBrighter : accentColorBright;
+    $: color = isSystemPowerOn ? accentColorBrighter : accentColorBright;
 </script>
 
 <IconButton
-    variant={$isPowerOn ? "outline" : "filled"}
+    variant={$isSystemPowerOn ? "outline" : "filled"}
     {color}
     disabled={!$isConnected}
     icon={IconPower}
     size={18}
-    on:click={$isPowerOn ? powerOff : powerOn}
+    on:click={$isSystemPowerOn ? powerOff : powerOn}
 />

--- a/src/lib/screens/Main.svelte
+++ b/src/lib/screens/Main.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { isPowerOn } from "../state.ts";
+    import { isStreamerPowerOn } from "../state.ts";
     import { seek } from "../vibin_api.ts";
     import Playhead from "../components/Playhead.svelte";
     import Standby from "../components/Standby.svelte";
@@ -17,7 +17,7 @@
 <div class="MainScreen">
     <div class="now-playing">
         <TrackInfo />
-        {#if $isPowerOn}
+        {#if $isStreamerPowerOn}
             <VolumeControls />
         {:else}
             <Standby />

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -43,6 +43,7 @@ type AppError = {
 // All known state information from the Vibin backend
 export type VibinState = {
     power?: Power,
+    streamer_power?: Power,
     amplifier?: Amplifier,
     display: StreamerDisplay,
     transport?: Transport,
@@ -89,7 +90,12 @@ async function createVibinHostState() {
 
 export const vibinHost = await createVibinHostState();
 
-export const isPowerOn = derived(vibinState, ($vibinState) => $vibinState.power === "on");
+// "System Power" represents both the streamer (always present) and the amplifier (optionally
+// present). The system is on when the streamer is on and the amplifier (if present) is on.
+// "Streamer Power" represents just the streamer (always present). This allows the UI to detect
+// when the streamer is on while the (optional) amplifier is off.
+export const isSystemPowerOn = derived(vibinState, ($vibinState) => $vibinState.power === "on");
+export const isStreamerPowerOn = derived(vibinState, ($vibinState) => $vibinState.streamer_power === "on");
 
 export const isConnected = derived(appState, ($appState) => $appState.vibin_connection.state === "Connected");
 


### PR DESCRIPTION
This fixes an issue where the UI would consider the streamer to be in standby when an amplifier is present and powered off, while the streamer was actually powered on (and not in standby).