### PR TITLE
Improve playhead position handling

### DIFF
--- a/src/lib/components/Playhead.svelte
+++ b/src/lib/components/Playhead.svelte
@@ -2,6 +2,13 @@
     import { playheadPosition, vibinState } from "../state.ts";
     import { colorFromCssVar } from "../utils.ts";
 
+    // The application's $playheadPosition might be undefined, which is a valid state representing
+    // "I'm probably not playing/paused right now". We want to display this as "--:--", but we
+    // also want to allow the slider to render at the zero position. So we distinguish between the
+    // application's $playheadPosition and this component's playheadPositionBindable ("bindable"
+    // because it is guaranteed to be a number which can be bound to the slider's value).
+    $: playheadPositionBindable = $playheadPosition || 0;
+
     $: progress = $playheadPosition && $vibinState.active_track?.duration ?
         ($playheadPosition / $vibinState.active_track.duration) * 100 : 0;
 
@@ -31,12 +38,12 @@
     <input
         style={cssVarStyles}
         class:can-seek={canSeek}
-        disabled={!canSeek}
+        disabled={!canSeek || typeof $playheadPosition === "undefined"}
         type="range"
         min="0"
         max={$vibinState.active_track?.duration}
         step="1"
-        bind:value={$playheadPosition}
+        bind:value={playheadPositionBindable}
         on:click
     />
     <span class="time">{prettyDuration($vibinState.active_track?.duration)}</span>


### PR DESCRIPTION
- In application state, set the playhead position to `undefined` whenever the streamer returns to an "on" power state from "off", or whenever the input source has changed. This logic should probably be owned by the Vibin backend.
- When rendering the playhead, always render an `undefined` playhead position as "--:--"; and ensure the playhead seek feature is disabled either when seeking is disabled on the streamer or when the playhead position is undefined.